### PR TITLE
Enhancement to render markdown files like nbconvert

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It features the following shortcodes:
 1. `[md_github token=YourToken url=Github URL]`: Pulls raw HTML from the `https://api.github.com/repos/` endpoint and styles it with Github markdown CSS
 2. `[checkout_github token=YourToken url=Github URL]`: Displays a formatted link to the repo with the date of the latest update
 3. `[history_github token=YourToken url=Github URL]`: Displays a commit history of the last 5 commits.
-4.  [md_dashedbox_github token=YourToken url=Github URL] : Displays GitHub markdown file similar to [nbconvert](https://github.com/ghandic/nbconvert).
+4. `[md_dashedbox_github token=YourToken url=Github URL]`: Displays GitHub markdown file similar to [nbconvert](https://github.com/ghandic/nbconvert). This shortcode is mutually exclusive with `md_github` and `checkout_github`.
 
 Github API is queried on every new load of the page, so that changes in the repository will immediately be reflected on your blog. Private authentication tokens help increasing the API limit to 5000 requests per hour (enough even for Digital Ocean blogs) and accessing private repositories.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ All shortcodes take `token` and `url` as attribute. `token` is your private pers
 Check it out on of our blogs:
 
 https://gis-ops.com/react-redux-leaflet-turfjs-building-a-density-based-clustering-dbscan-app-with-the-almighty-here-maps-places-api/
+
 https://www.beyond-storage.com/wordpress-plugin-github-markdown
 
 ## Wordpress versions

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Advantages:
 - Easy to update by external users via pull requests, minimizes the chance of stale tutorials
 - Write Markdown in your favorite editor and just push to your repo to update your blog
 
-It features 3 shortcodes:
+It features the following shortcodes:
 
 1. `[md_github token=YourToken url=Github URL]`: Pulls raw HTML from the `https://api.github.com/repos/` endpoint and styles it with Github markdown CSS
 2. `[checkout_github token=YourToken url=Github URL]`: Displays a formatted link to the repo with the date of the latest update
 3. `[history_github token=YourToken url=Github URL]`: Displays a commit history of the last 5 commits.
-4.  [mdnotebook_github token=YourToken url=Github URL] : Displays GitHub markdown file similar to nbconvert.
+4.  [md_dashedbox_github token=YourToken url=Github URL] : Displays GitHub markdown file similar to [nbconvert](https://github.com/ghandic/nbconvert).
 
 Github API is queried on every new load of the page, so that changes in the repository will immediately be reflected on your blog. Private authentication tokens help increasing the API limit to 5000 requests per hour (enough even for Digital Ocean blogs) and accessing private repositories.
 
@@ -28,7 +28,7 @@ All shortcodes take `token` and `url` as attribute. `token` is your private pers
 
 `[history_github token=1d6ef5ba426648ef7d2273aca2fc80787 url=https://github.com/gis-ops/tutorials/blob/master/qgis/QGIS_PluginBasics.md]`
 
-`[mdnotebook_github token=1d6ef5ba426648ef7d2273aca2fc80787 url=https://github.com/gis-ops/tutorials/blob/master/qgis/QGIS_PluginBasics.md]`
+`[md_dashedbox_github token=1d6ef5ba426648ef7d2273aca2fc80787 url=https://github.com/gis-ops/tutorials/blob/master/qgis/QGIS_PluginBasics.md]`
 
 ## Demo
 
@@ -43,3 +43,7 @@ https://www.beyond-storage.com/wordpress-plugin-github-markdown
 **Min**: v4.0
 
 **Tested up to**: 5.0.2
+
+
+## Contributors
+- Ulf Troppens: storageulf@gmail.com

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It features 3 shortcodes:
 1. `[md_github token=YourToken url=Github URL]`: Pulls raw HTML from the `https://api.github.com/repos/` endpoint and styles it with Github markdown CSS
 2. `[checkout_github token=YourToken url=Github URL]`: Displays a formatted link to the repo with the date of the latest update
 3. `[history_github token=YourToken url=Github URL]`: Displays a commit history of the last 5 commits.
+4.  [mdnotebook_github token=YourToken url=Github URL] : Displays GitHub markdown file similar to nbconvert.
 
 Github API is queried on every new load of the page, so that changes in the repository will immediately be reflected on your blog. Private authentication tokens help increasing the API limit to 5000 requests per hour (enough even for Digital Ocean blogs) and accessing private repositories.
 
@@ -27,11 +28,14 @@ All shortcodes take `token` and `url` as attribute. `token` is your private pers
 
 `[history_github token=1d6ef5ba426648ef7d2273aca2fc80787 url=https://github.com/gis-ops/tutorials/blob/master/qgis/QGIS_PluginBasics.md]`
 
+`[mdnotebook_github token=1d6ef5ba426648ef7d2273aca2fc80787 url=https://github.com/gis-ops/tutorials/blob/master/qgis/QGIS_PluginBasics.md]`
+
 ## Demo
 
 Check it out on of our blogs:
 
 https://gis-ops.com/react-redux-leaflet-turfjs-building-a-density-based-clustering-dbscan-app-with-the-almighty-here-maps-places-api/
+https://www.beyond-storage.com/wordpress-plugin-github-markdown
 
 ## Wordpress versions
 

--- a/css/md-github.css
+++ b/css/md-github.css
@@ -8,7 +8,7 @@ div.md_dashedbox {
     margin-bottom:15px
 }
 
-div.mdnotebook div.markdown-github {
+div.md_dashedbox div.markdown-github {
   color:white;
   line-height: 20px;
   padding: 0px 5px;

--- a/css/md-github.css
+++ b/css/md-github.css
@@ -1,4 +1,26 @@
 /*From https://github.com/ghandic/nbconvert/blob/master/css/nbconvert.css*/
+
+div.mdnotebook {
+    position: relative;
+    font-size: 0.75em;
+    border: 3px dashed;
+    padding: 10px;
+    margin-bottom:15px
+}
+
+div.mdnotebook div.markdown-github {
+  color:white;
+  line-height: 20px;
+  padding: 0px 5px;
+  position: absolute;
+  background-color: #345;
+  top: -3px;
+  left: -3px;
+  text-transform:none;
+  font-size:1em;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
 div.markdown-github {
   position: relative;
   font-size: 0.75em;

--- a/css/md-github.css
+++ b/css/md-github.css
@@ -1,6 +1,6 @@
 /*From https://github.com/ghandic/nbconvert/blob/master/css/nbconvert.css*/
 
-div.mdnotebook {
+div.md_dashedbox {
     position: relative;
     font-size: 0.75em;
     border: 3px dashed;

--- a/md_github.php
+++ b/md_github.php
@@ -105,20 +105,20 @@ function MDGH_md_github_handler($atts) {
     return $res;
 }
 
-function MDGH_mdnotebook_github_handler($atts) {
+function MDGH_md_dashedbox_github($atts) {
     list($url, $token) = MDGH_atts_extract($atts);
     //get checkout lable from file URL
     $checkout = MDGH_md_github_checkout($atts);
     //get raw markdown from file URL
     $markdown = MDGH_get_api_response($url, $token, 'file');
     //generate frame with border, checkout label and markdown content
-    $mdnotebook = '
-      <div class="mdnotebook">
+    $md_dashedbox = '
+      <div class="md_dashedbox">
         '.$checkout.'
         '.$markdown.'
       </div>';
     //send back text to replace shortcode in post
-    return $mdnotebook;
+    return $md_dashedbox;
 }
 
 function MDGH_md_github_checkout($atts) {
@@ -143,6 +143,7 @@ function MDGH_md_github_enqueue_style() {
 }
 add_action( 'wp_enqueue_scripts', 'MDGH_md_github_enqueue_style' );
 add_shortcode('checkout_github', "MDGH_md_github_checkout");
-add_shortcode("md_github", "MDGH_md_github_handler");
 add_shortcode("mdnotebook_github", "MDGH_mdnotebook_github_handler");
 add_shortcode('history_github', "MDHG_md_github_history");
+add_shortcode("md_dashedbox_github", "MDGH_md_dashedbox_github");
+

--- a/md_github.php
+++ b/md_github.php
@@ -143,7 +143,7 @@ function MDGH_md_github_enqueue_style() {
 }
 add_action( 'wp_enqueue_scripts', 'MDGH_md_github_enqueue_style' );
 add_shortcode('checkout_github', "MDGH_md_github_checkout");
-add_shortcode("mdnotebook_github", "MDGH_mdnotebook_github_handler");
+add_shortcode("md_github", "MDGH_md_github_handler");
 add_shortcode('history_github', "MDHG_md_github_history");
 add_shortcode("md_dashedbox_github", "MDGH_md_dashedbox_github");
 

--- a/md_github.php
+++ b/md_github.php
@@ -3,7 +3,7 @@
 Plugin Name: Markdown Github
 Description: A plugin to inject markdown files directly into a post from Github
 Plugin URI: https://github.com/gis-ops/md-github-wordpress
-Version: 1.1.0
+Version: 1.2.0
 Author: Nils Nolde
 Author URI: https://gis-ops.com
 License: GPLv2
@@ -105,6 +105,22 @@ function MDGH_md_github_handler($atts) {
     return $res;
 }
 
+function MDGH_mdnotebook_github_handler($atts) {
+    list($url, $token) = MDGH_atts_extract($atts);
+    //get checkout lable from file URL
+    $checkout = MDGH_md_github_checkout($atts);
+    //get raw markdown from file URL
+    $markdown = MDGH_get_api_response($url, $token, 'file');
+    //generate frame with border, checkout label and markdown content
+    $mdnotebook = '
+      <div class="mdnotebook">
+        '.$checkout.'
+        '.$markdown.'
+      </div>';
+    //send back text to replace shortcode in post
+    return $mdnotebook;
+}
+
 function MDGH_md_github_checkout($atts) {
     list($url, $token) = MDGH_atts_extract($atts);
     // query commit endpoint for latest update time
@@ -128,4 +144,5 @@ function MDGH_md_github_enqueue_style() {
 add_action( 'wp_enqueue_scripts', 'MDGH_md_github_enqueue_style' );
 add_shortcode('checkout_github', "MDGH_md_github_checkout");
 add_shortcode("md_github", "MDGH_md_github_handler");
+add_shortcode("mdnotebook_github", "MDGH_mdnotebook_github_handler");
 add_shortcode('history_github', "MDHG_md_github_history");


### PR DESCRIPTION
PHP and CSS code to render a GitHub markdown file like nbconvert. This addresses feature request #5.
The below web page is created with the new shortcut.

![image](https://user-images.githubusercontent.com/22422468/67619969-02ac9a80-f802-11e9-82c5-638d7d13ed9c.png)
